### PR TITLE
TUI development

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.21.5
 require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.2
+	github.com/charmbracelet/lipgloss v0.9.1
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -18,7 +17,7 @@ import (
 // NOTE:
 // Styles
 var (
-	bg = lipgloss.Color("#4F6F52")
+	fg = lipgloss.Color("#EEEEEE")
 )
 
 func main() {
@@ -38,6 +37,7 @@ type Model struct {
 	title     string
 	terms     Terms
 	textinput textinput.Model
+	height    int
 	width     int
 	err       error
 }
@@ -66,7 +66,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Switch though msg types
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width - 8
+		m.height = msg.Height
+		m.width = msg.Width
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c":
@@ -102,23 +103,18 @@ func (m Model) View() string {
 
 	if len(m.terms.List) > 0 {
 
-		// BUG:
-		// *** Possible solution to line wrapping? (currently only wraps the first set of m.width characters) ***
-		// Store a copy of Definition an a variable (text)
-		// Loop though the text variable while the len is less than m.width
-		// Slice the text string and add it to the return string
-		// Store the m.width slice result back into text to decrament it
+		w := m.width - 8
 
-		if len(m.terms.List[0].Definition) < m.width {
+		if len(m.terms.List[0].Definition) < w {
 			s += m.terms.List[0].Definition + "\n\n"
 		} else {
 			// Check if byte as index 99 in string is a space
-			if m.terms.List[0].Definition[m.width] != 32 {
-				s += m.terms.List[0].Definition[:m.width] + "-\n"
+			if m.terms.List[0].Definition[w] != 32 {
+				s += m.terms.List[0].Definition[:w] + "-\n"
 			} else {
-				s += m.terms.List[0].Definition[:m.width] + "\n"
+				s += m.terms.List[0].Definition[:w] + "\n"
 			}
-			s += m.terms.List[0].Definition[m.width:] + "\n\n"
+			s += m.terms.List[0].Definition[w:] + "\n\n"
 		}
 
 		s += m.terms.List[0].Example + "\n\n"
@@ -127,10 +123,12 @@ func (m Model) View() string {
 
 	style := lipgloss.NewStyle().
 		SetString(s).
-		Background(bg).
+		Foreground(fg).
 		Bold(true).
 		PaddingLeft(4).
-		PaddingRight(4)
+		PaddingRight(4).
+		Width(m.width).
+		Height(m.height)
 
 	return style.Render()
 }


### PR DESCRIPTION
## Description
Adds terminal styling to the application with the golang bubble-tea framework

## Problems
The text does not fully wrap around the terminal (only the initial length of the width wraps) 
Text wrapping should add a (-) to indicate the word continues on a new line

i.e
<img width="1710" alt="Screenshot 2024-05-15 at 9 16 00 PM" src="https://github.com/luka2220/dictionary-cli/assets/42144047/0c0367aa-96f7-4f88-85ed-5230e11c29a9">
